### PR TITLE
Change sendToParent error to throw asynchronously

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple postMessage based server.",
   "main": "dist/post-robot.min.js",
   "scripts": {
-    "test": "gulp lint"
+    "test": "gulp karma"
   },
   "repository": {
     "type": "git",

--- a/src/interface/client.js
+++ b/src/interface/client.js
@@ -131,8 +131,8 @@ export function sendToParent(name, data, options, callback) {
 
     let win = getParentWindow();
 
-    if (!window) {
-        throw new Error('Window does not have a parent');
+    if (!win) {
+        return new promise.Promise((resolve, reject) => reject(new Error('Window does not have a parent')));
     }
 
     return send(win, name, data, options, callback);


### PR DESCRIPTION
- Currently, if there is no parent, then the error is thrown synchronously with `throw`. However, any errors with the send are thrown asynchronously.
- To prevent having to catch both asynchronous and synchronous errors, this PR changes the `throw` to return a rejected promise instead

## Changes
- Change `throw` to return a rejected promise instead
- Change `npm test` to also run the karma tests