### PR TITLE
feat(client): Allow iframe node in send function

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,8 @@
     "window": true,
     "document": true,
     "Promise": false,
-    "__TEST__": true
+    "__TEST__": true,
+    "HTMLElement": true
   },
 
   "fix": true,

--- a/src/interface/client.js
+++ b/src/interface/client.js
@@ -13,11 +13,7 @@ export function request(options) {
             throw new Error('Expected options.name');
         }
 
-        if (!options.window) {
-            throw new Error('Expected options.window');
-        }
-
-
+        
         if (CONFIG.MOCK_MODE) {
             options.window = window;
 
@@ -32,11 +28,28 @@ export function request(options) {
                 throw new Error(`Expected options.window ${options.window} to be an iframe`);
             }
 
+            if (!el.contentWindow) {
+                throw new Error('Iframe must have contentWindow.  Make sure it has a src attribute and is in the DOM.');
+            }
+
             options.window = el.contentWindow;
 
-            if (!options.window) {
-                throw new Error('Expected options.window');
+            
+        } else if (options.window instanceof HTMLElement) {
+            
+            if (options.window.tagName.toLowerCase() !== 'iframe') {
+                throw new Error(`Expected options.window ${options.window} to be an iframe`);
             }
+
+            if (!options.window.contentWindow) {
+                throw new Error('Iframe must have contentWindow.  Make sure it has a src attribute and is in the DOM.');
+            }
+            
+            options.window = options.window.contentWindow;
+        }
+
+        if (typeof options.window !== 'object' || options.window === null) { 
+            throw new Error('Expected options.window to be a window object, iframe, or iframe element id.');
         }
 
         options.domain = options.domain || '*';

--- a/test/test.js
+++ b/test/test.js
@@ -25,7 +25,7 @@ function createPopup(name) {
 
 let bridge;
 
-let childWindow, childFrame, otherChildFrame;
+let childWindow, childFrame, otherChildFrame, frameElement;
 
 before(function() {
     return postRobot.openBridge('/base/test/bridge.htm', 'mock://test-post-robot-child.com').then(frame => {
@@ -35,6 +35,7 @@ before(function() {
         childWindow = createPopup('child.htm');
         childFrame = createIframe('child.htm');
         otherChildFrame = createIframe('child.htm');
+        frameElement = document.getElementById('childframe');
 
         return promise.Promise.all([
             onWindowReady(childWindow),
@@ -53,6 +54,23 @@ after(function() {
 
 
 describe('[post-robot] happy cases', function() {
+
+    it('should allow an iframe dom element in send function', function() {
+
+        return postRobot.send(frameElement, 'setupListener', {
+
+            messageName: 'foo',
+            data: {
+                foo: 'bar'
+            }
+
+        }).then(function() {
+
+            return postRobot.send(frameElement, 'foo').then(function({ data }) {
+                assert.equal(data.foo, 'bar');
+            });
+        });
+    });
 
     it('should set up a simple server and listen for a request', function(done) {
 


### PR DESCRIPTION
I first tried to use the library like this and it errored.  The docs really don't say much about iframe.contentWindow so I had to do some searching.  I think this makes sense and may save confusion.

Allows:
```
var frame = document.getElementById('myFrame');
postRobot.send(frame, 'test', data);
```

Also moved the options.window check to after all the ways to set options.window are complete.  Make sure at the very end options.window.document exists.