### PR TITLE
Add ALLOW_SAME_WINDOW flag for content-script <-> page messaging

### DIFF
--- a/src/conf/config.js
+++ b/src/conf/config.js
@@ -24,7 +24,8 @@ export let CONFIG : Object = {
         [ CONSTANTS.SEND_STRATEGIES.GLOBAL ]:       true
     },
 
-    ALLOW_SAME_ORIGIN: false
+    ALLOW_SAME_ORIGIN: false,
+    ALLOW_SAME_WINDOW: false
 };
 
 if (window.location.href.indexOf(CONSTANTS.FILE_PROTOCOL) === 0) {

--- a/src/drivers/receive/types.js
+++ b/src/drivers/receive/types.js
@@ -3,7 +3,7 @@
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { isWindowClosed, matchDomain, stringifyDomainPattern, type CrossDomainWindowType } from 'cross-domain-utils/src';
 
-import { CONSTANTS } from '../../conf';
+import { CONSTANTS, CONFIG } from '../../conf';
 import { log, stringifyError, noop } from '../../lib';
 import { sendMessage } from '../send';
 import { getRequestListener, getResponseListener, deleteResponseListener, isResponseListenerErrored } from '../listeners';
@@ -19,6 +19,10 @@ export let RECEIVE_MESSAGE_TYPES = {
         let options = getResponseListener(message.hash);
 
         if (!options) {
+            if (CONFIG.ALLOW_SAME_WINDOW) {
+                return;
+            }
+
             throw new Error(`No handler found for post message ack for message: ${ message.name } from ${ origin } in ${ window.location.protocol }//${ window.location.host }${ window.location.pathname }`);
         }
 
@@ -32,6 +36,10 @@ export let RECEIVE_MESSAGE_TYPES = {
     [ CONSTANTS.POST_MESSAGE_TYPE.REQUEST ](source : CrossDomainWindowType, origin : string, message : Object) : ZalgoPromise<void> {
 
         let options = getRequestListener({ name: message.name, win: source, domain: origin });
+
+        if (!options && CONFIG.ALLOW_SAME_WINDOW) {
+            return ZalgoPromise.resolve();
+        }
 
         function respond(data) : ZalgoPromise<void> {
 
@@ -108,6 +116,10 @@ export let RECEIVE_MESSAGE_TYPES = {
         let options = getResponseListener(message.hash);
 
         if (!options) {
+            if (CONFIG.ALLOW_SAME_WINDOW) {
+                return;
+            }
+
             throw new Error(`No handler found for post message response for message: ${ message.name } from ${ origin } in ${ window.location.protocol }//${ window.location.host }${ window.location.pathname }`);
         }
 

--- a/src/drivers/send/index.js
+++ b/src/drivers/send/index.js
@@ -45,7 +45,7 @@ export function sendMessage(win : CrossDomainWindowType, message : Object, domai
 
         log.logLevel(level, [ '\n\n\t', '#send', message.type.replace(/^postrobot_message_/, ''), '::', message.name, '::', domain || CONSTANTS.WILDCARD, '\n\n', message ]);
 
-        if (win === window && !CONFIG.ALLOW_SAME_ORIGIN) {
+        if (win === window && !CONFIG.ALLOW_SAME_ORIGIN && !CONFIG.ALLOW_SAME_WINDOW) {
             throw new Error('Attemping to send message to self');
         }
 


### PR DESCRIPTION
When `CONFIG.ALLOW_SAME_WINDOW` is set to `true`, allow messages to the the same window and ignore requests from this instance. Turned off by default for compatibility.

The idea is that you have another instance in another context/sandbox bound to the same window that wants to talk to us. This is common in WebExtensions.

This is similar to `CONFIG.ALLOW_SAME_ORIGIN` but also prevents _post-robot_ from confusion when it sees its own requests by discarding them early.

I found this useful for my projects, thought I'd make a PR.
**Question for maintainers:** should I add a mention of `conf/config.js` in the README? I don't see any docs on the config and stumbled upon it by accident. Maybe I'm blind.

Thanks for the awesome package!