### PR TITLE
Remove fuzzy match for remote bridge frame

### DIFF
--- a/src/bridge/child.js
+++ b/src/bridge/child.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { ZalgoPromise } from 'zalgo-promise/src';
-import { isSameDomain, getOpener, getFrames, getDomain, getFrameByName, type CrossDomainWindowType } from 'cross-domain-utils/src';
+import { isSameDomain, getOpener, getDomain, getFrameByName, type CrossDomainWindowType } from 'cross-domain-utils/src';
 import { weakMapMemoize, noop } from 'belter/src';
 
 import { CONSTANTS } from '../conf';
@@ -11,18 +11,6 @@ import { needsBridge, registerRemoteWindow, rejectRemoteSendMessage, registerRem
 
 let awaitRemoteBridgeForWindow = weakMapMemoize((win : CrossDomainWindowType) : ZalgoPromise<?CrossDomainWindowType> => {
     return ZalgoPromise.try(() => {
-        for (let frame of getFrames(win)) {
-            try {
-                // $FlowFixMe
-                if (frame && frame !== window && isSameDomain(frame) && frame[CONSTANTS.WINDOW_PROPS.POSTROBOT]) {
-                    return frame;
-                }
-
-            } catch (err) {
-                continue;
-            }
-        }
-
         try {
             let frame = getFrameByName(win, getBridgeName(getDomain()));
 


### PR DESCRIPTION
Issue: #64 

The fuzzy match for a remote bridge frame fails on pages where there are multiple frames using post-robot or zoid. The logic assumes that a frame is a remote bridge if post-robot exists on the frame window object - but this is not always the case.

I'm unclear why the check utilizing [getFrameByName](https://github.com/krakenjs/post-robot/blob/98e6ac519c009902713e6c3404f46004c5aa532f/src/bridge/child.js#L27) is not the first frame-match strategy for finding a remote bridge frame.