### PR TITLE
Fix: Throw Error if window is closed when type is serialized

### DIFF
--- a/src/serialize/window.js
+++ b/src/serialize/window.js
@@ -46,9 +46,9 @@ function getSerializedWindow(winPromise : ZalgoPromise<CrossDomainWindowType>, {
         id,
         getType: () => winPromise.then(win => {
             if (isWindowClosed(win)) {
-                return WINDOW_TYPE.CLOSED;
+                throw new Error(`Cannot determine the type of a closed window.`);
             }
-
+            
             return getOpener(win) ? WINDOW_TYPE.POPUP : WINDOW_TYPE.IFRAME;
         }),
         getInstanceID: memoizePromise(() => winPromise.then(win => getWindowInstanceID(win, { send }))),

--- a/src/serialize/window.js
+++ b/src/serialize/window.js
@@ -42,11 +42,19 @@ function getSerializedWindow(winPromise : ZalgoPromise<CrossDomainWindowType>, {
         }
     });
     
+    const windowTypePromise = winPromise.then(window => {
+        if (!isWindowClosed(window)) {
+            return getOpener(window) ? WINDOW_TYPE.POPUP : WINDOW_TYPE.IFRAME;
+        } else {
+            throw new Error(`Window is closed, can not determine type`);
+        }
+    });
+
     return {
         id,
-        getType: () => winPromise.then(win => {
-            return getOpener(win) ? WINDOW_TYPE.POPUP : WINDOW_TYPE.IFRAME;
-        }),
+        getType: () => {
+            return windowTypePromise;
+        },
         getInstanceID: memoizePromise(() => winPromise.then(win => getWindowInstanceID(win, { send }))),
         close:         () => winPromise.then(closeWindow),
         getName:       () => winPromise.then(win => {
@@ -116,7 +124,6 @@ export class ProxyWindow {
     id : string
     isProxyWindow : true = true
     serializedWindow : SerializedWindowType
-    serializedWindowType : ZalgoPromise<$Values<typeof WINDOW_TYPE>>
     actualWindow : ?CrossDomainWindowType
     actualWindowPromise : ZalgoPromise<CrossDomainWindowType>
     send : SendType
@@ -125,7 +132,6 @@ export class ProxyWindow {
     constructor({ send, win, serializedWindow } : {| win? : CrossDomainWindowType, serializedWindow? : SerializedWindowType, send : SendType |}) {
         this.actualWindowPromise = new ZalgoPromise();
         this.serializedWindow = serializedWindow || getSerializedWindow(this.actualWindowPromise, { send });
-        this.serializedWindowType = this.serializedWindow.getType();
         
         globalStore('idToProxyWindow').set(this.getID(), this);
         if (win) {
@@ -138,7 +144,7 @@ export class ProxyWindow {
     }
 
     getType() : ZalgoPromise<$Values<typeof WINDOW_TYPE>> {
-        return this.serializedWindowType;
+        return this.serializedWindow.getType();
     }
 
     isPopup() : ZalgoPromise<boolean> {

--- a/src/serialize/window.js
+++ b/src/serialize/window.js
@@ -45,6 +45,10 @@ function getSerializedWindow(winPromise : ZalgoPromise<CrossDomainWindowType>, {
     return {
         id,
         getType: () => winPromise.then(win => {
+            if (isWindowClosed(win)) {
+                return WINDOW_TYPE.CLOSED;
+            }
+
             return getOpener(win) ? WINDOW_TYPE.POPUP : WINDOW_TYPE.IFRAME;
         }),
         getInstanceID: memoizePromise(() => winPromise.then(win => getWindowInstanceID(win, { send }))),

--- a/test/test.js
+++ b/test/test.js
@@ -774,7 +774,11 @@ describe('[post-robot] serialization cases', () => {
         }).then(({ data }) => {
             return data.mywindow.close();
 
-        }).then(() => {
+        }).then((win) => {
+            if (!win.isPopup()) {
+                throw new Error(`Expected window to be a POPUP`);
+            }
+
             if (!mywindow.closed) {
                 throw new Error(`Expected window to be closed`);
             }

--- a/test/test.js
+++ b/test/test.js
@@ -778,7 +778,7 @@ describe('[post-robot] serialization cases', () => {
             if (!win.isPopup()) {
                 throw new Error(`Expected window to be a POPUP`);
             }
-
+        
             if (!mywindow.closed) {
                 throw new Error(`Expected window to be closed`);
             }


### PR DESCRIPTION
IFRAME type was being returned if popup window was closed immediately causing the spinner to overlay the primary page.
https://github.com/paypal/paypal-checkout-components/issues/1339