### PR TITLE
Add cancelAll function

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ var listener = postRobot.on('getUser', function(event) {
 listener.cancel();
 ```
 
+## Cancelling all listeners
+
+```javascript
+postRobot.cancelAll();
+```
+
 ## Listen for messages from a specific window
 
 ```javascript

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export { ZalgoPromise as Promise } from 'zalgo-promise/src';
 export * from './types';
 export { ProxyWindow } from './serialize';
 export { setup, destroy, serializeMessage, deserializeMessage, createProxyWindow, toProxyWindow } from './setup';
-export { on, once, send } from './public';
+export { on, once, send, cancelAll } from './public';
 export { markWindowKnown } from './lib';
 export { cleanUpWindow } from './clean';
 

--- a/src/public/cancel.js
+++ b/src/public/cancel.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+import { cancelResponseListeners } from '../drivers';
+
+export function cancelAll() {
+    cancelResponseListeners();
+}

--- a/src/public/index.js
+++ b/src/public/index.js
@@ -2,3 +2,4 @@
 
 export * from './on';
 export * from './send';
+export * from './cancel';


### PR DESCRIPTION
Partially Resolves #41 .

This PR exports the `cancelResponseListeners` function under the postRobot object as `postRobot.cancelAll()`.

#hacktoberfest !