### PR TITLE
Issue related to lost lost popup focus and onApprove not calling

### DIFF
--- a/src/serialize/window.js
+++ b/src/serialize/window.js
@@ -213,7 +213,7 @@ export class ProxyWindow {
 
         const reopenPromise = ZalgoPromise.hash({ isPopup: isPopupPromise, name: getNamePromise }).then(({ isPopup, name }) => {
             if (isPopup && name) {
-                window.open('', name);
+                window.open('', name, 'noopener');
             }
         });
         const focusPromise = this.serializedWindow.focus();


### PR DESCRIPTION
### Description
This PR contains a fix available in almost all modern browsers using [noopener](https://caniuse.com/rel-noopener) related to the issue reported about the merchant not receiving the onApprove callback after the PayPal checkout process. 

### Why are we making these changes:
Please refer to these links: 
[JIRA](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-581)
[GitHub](https://github.com/paypal/react-paypal-js/issues/208)

### Reproduction Steps
On the PayPal smart buttons follow these steps:
1. Click on the payment button
2. Click outside anywhere on the page, the popup disappears.
3. Click on the `Click to Continue` message on the PayPal modal.
4. If you log in the communication between the child and parent is broken and the popup is not able to call the `onInit`or `onApprove` callbacks.

### Explanation
The problem here is how the browser `window.open` API works. The short history is the open will set interface `opener` inside the opened URL with the window context where the `open` API was called. We're using the `window.open('', name)` to get the focus on the popup. That means will override the opener all the time we use this approach, base on the Browser API description here [Window.opener](https://developer.mozilla.org/en-US/docs/Web/API/Window/opener).
To avoid this browser behavior we need to pass the `noopener` windowFeature` as a third param, this guarantees will not modify the original opener interface on the PayPal popup. 