### PR TITLE
feat: upgrade to grumbler scripts 8

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,7 @@
 /* @flow */
 
 module.exports = {
-  extends:
-    "./node_modules/@krakenjs/grumbler-scripts/config/.eslintrc-browser.js",
+  extends: "@krakenjs/eslint-config-grumbler/eslintrc-browser",
 
   globals: {
     __POST_ROBOT__: true,

--- a/.flowconfig
+++ b/.flowconfig
@@ -10,7 +10,6 @@
 [libs]
 flow-typed
 src/declarations.js
-node_modules/@krakenjs/grumbler-scripts/declarations.js
 [options]
 module.name_mapper='^src\(.*\)$' -> '<PROJECT_ROOT>/src/\1'
 experimental.const_params=false

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,5 @@
 
 // eslint-disable-next-line import/no-commonjs
 module.exports = {
-  extends: "@krakenjs/grumbler-scripts/config/.babelrc-node",
+  extends: "@krakenjs/babel-config-grumbler/babel-node",
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,5 @@
 
 // eslint-disable-next-line import/no-commonjs
 module.exports = {
-  extends: "@krakenjs/babel-config-grumbler/babel-node",
+  extends: "@krakenjs/babel-config-grumbler/babelrc-node",
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint import/no-default-export: off */
 
-import { getKarmaConfig } from "@krakenjs/grumbler-scripts/config/karma.conf";
+import { getKarmaConfig } from "@krakenjs/karma-config-grumbler";
 
 import { WEBPACK_CONFIG_TEST } from "./webpack.config";
 

--- a/package.json
+++ b/package.json
@@ -91,9 +91,12 @@
   "devDependencies": {
     "@commitlint/cli": "^16.2.1",
     "@commitlint/config-conventional": "^16.2.1",
-    "@krakenjs/grumbler-scripts": "^7.0.0",
+    "@krakenjs/grumbler-scripts": "^8.0.3",
+    "cross-env": "^7.0.3",
     "flow-bin": "0.155.0",
+    "flow-typed": "^3.8.0",
     "husky": "^7.0.4",
+    "jest": "^29.3.1",
     "lint-staged": "^12.4.0",
     "mocha": "^4",
     "prettier": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "devDependencies": {
     "@commitlint/cli": "^16.2.1",
     "@commitlint/config-conventional": "^16.2.1",
-    "@krakenjs/grumbler-scripts": "^8.0.3",
+    "@krakenjs/grumbler-scripts": "^8.0.4",
     "cross-env": "^7.0.3",
     "flow-bin": "0.155.0",
     "flow-typed": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format:check": "prettier --check .",
     "karma": "cross-env NODE_ENV=test babel-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/karma start",
     "babel": "babel src/ --out-dir dist/module",
-    "webpack": "babel-node --config-file ./node_modules/@krakenjs/grumbler-scripts/config/.babelrc-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/webpack --display-optimization-bailout --progress",
+    "webpack": "babel-node --config-file ./node_modules/@krakenjs/grumbler-scripts/config/.babelrc-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/webpack --progress",
     "test": "npm run format:check && npm run lint && npm run flow-typed && npm run flow && npm run karma",
     "build": "npm run test && npm run babel && npm run webpack -- $@",
     "clean": "rimraf dist coverage",

--- a/src/declarations.js
+++ b/src/declarations.js
@@ -9,3 +9,4 @@ declare var __POST_ROBOT__: {|
 |};
 
 declare var __TEST__: boolean;
+declare var __DEBUG__: boolean;

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,7 +1,0 @@
-/* @flow */
-/* eslint import/no-commonjs: off */
-
-module.exports = {
-  extends:
-    "../node_modules/@krakenjs/grumbler-scripts/config/.eslintrc-browser-test.js",
-};

--- a/test/tests/serialization.js
+++ b/test/tests/serialization.js
@@ -154,7 +154,7 @@ describe("Serialization cases", () => {
     const expectedValue = 123;
     let resolver;
 
-    // eslint-disable-next-line promise/no-native, no-restricted-globals
+    // eslint-disable-next-line promise/no-native, no-restricted-globals, compat/compat
     const promise = new Promise((resolve) => {
       resolver = resolve;
     });
@@ -196,7 +196,7 @@ describe("Serialization cases", () => {
     let expectedErrorStack; // eslint-disable-line prefer-const
     let rejector;
 
-    // eslint-disable-next-line promise/no-native, no-restricted-globals
+    // eslint-disable-next-line promise/no-native, no-restricted-globals, compat/compat
     const promise = new Promise((resolve, reject) => {
       rejector = reject;
     });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,11 @@
 /* @flow */
 /* eslint import/no-nodejs-modules: off, import/no-default-export: off, import/default: off */
 
-import type { WebpackConfig } from "@krakenjs/grumbler-scripts/config/types";
+import type { WebpackConfig } from "@krakenjs/webpack-config-grumbler/index.flow";
 import {
   getWebpackConfig,
   getNextVersion,
-} from "@krakenjs/grumbler-scripts/config/webpack.config";
+} from "@krakenjs/webpack-config-grumbler";
 import { argv } from "yargs";
 
 import pkg from "./package.json";


### PR DESCRIPTION
[DTPPSDK-954](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-954)

* Migrated to grumbler scripts v8.  
* Added `flow-typed`, `jest`, and `cross-env` as explicit dev-dependencies.  
* Added declaration for __DEBUG__ to resolve flow error
* Removed `/test/eslintrc`