### PR TITLE
feat: add check if listener exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ export {
   createProxyWindow,
   toProxyWindow,
 } from "./setup";
-export { on, once, send } from "./public";
+export { on, once, send, listenerExists } from "./public";
 export { markWindowKnown } from "./lib";
 export { cleanUpWindow } from "./clean";
 

--- a/src/public/index.js
+++ b/src/public/index.js
@@ -2,3 +2,4 @@
 
 export * from "./on";
 export * from "./send";
+export * from "./listenerExists";

--- a/src/public/listenerExists.js
+++ b/src/public/listenerExists.js
@@ -1,0 +1,34 @@
+/* @flow */
+
+import { getRequestListener } from "../drivers";
+import type { ServerOptionsType } from "../types";
+
+const getDefaultServerOptions = (): ServerOptionsType => {
+  // $FlowFixMe
+  return {};
+};
+
+export function listenerExists(
+  name: string,
+  options: ?ServerOptionsType
+): boolean {
+  if (!name) {
+    throw new Error("Expected name");
+  }
+
+  options = options || getDefaultServerOptions();
+
+  const win = options.window;
+  const domain = options.domain;
+
+  if (Array.isArray(domain)) {
+    for (const item of domain) {
+      if (getRequestListener({ name, win, domain: item })) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  return Boolean(getRequestListener({ name, win, domain }));
+}


### PR DESCRIPTION
Hi everyone I just repeated the pr as it had some conflict in it for simplicity I've added this as a new one.
In my use case, I need this function to check if the listener was defined in the host of the iframe and then call the native behavior of the host if the listener was not specified in other cases call the listener.
This pr is just a copy of https://github.com/krakenjs/post-robot/pull/91 for bringing attention to this